### PR TITLE
fix deprecated secret replication

### DIFF
--- a/Module/IAM/main.tf
+++ b/Module/IAM/main.tf
@@ -75,7 +75,7 @@ resource "google_project_iam_member" "valohai_sa_user" {
 resource "google_secret_manager_secret" "valohai_master_sa" {
   secret_id = "valohai_master_sa"
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/Module/Worker-Queue/main.tf
+++ b/Module/Worker-Queue/main.tf
@@ -1,7 +1,7 @@
 resource "google_secret_manager_secret" "redis_password" {
   secret_id = "valohai_redis_password"
   replication {
-    automatic = true
+    auto {}
   }
 }
 resource "random_password" "password" {


### PR DESCRIPTION
* The correct syntax is now (as per [TF docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version)):
```
  replication {
    auto {}
  }
```